### PR TITLE
experimental cli export feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.pro.user*
 *.autosave
+deploy/
+.ignore/

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Also, suggestions, feature requests, and new ideas are welcome. Please open issu
 
 On itch.io, you can download the tool for free, or choose to pay any amount to support the project.
 
-You can also support the development on [patreon](https://www.patreon.com/azagaya), 
+You can also support the development on [patreon](https://www.patreon.com/azagaya),
 or support it by paypal: [![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://paypal.me/PabloFonovich).
 
 Now you can also [![ko-fi](https://www.ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/O5O110W22)
@@ -29,3 +29,32 @@ If you wan't to contribute by coding, please contact me and we will see how can 
 ![captura-piedra-5](https://user-images.githubusercontent.com/46932830/60845822-dcf87880-a1b3-11e9-879c-e909fbd83469.png)
 ![captura-piedras-9](https://user-images.githubusercontent.com/46932830/60845823-dcf87880-a1b3-11e9-8772-a42180f3abdc.png)
 ![specular4](https://user-images.githubusercontent.com/46932830/60845825-dcf87880-a1b3-11e9-9f32-45ccc27abe0f.png)
+
+
+## Compiling on Windows
+
+Compiling on linux is pretty straightforward, just use your package manager to install qtcreator, libopencv-dev and thats it, you can open the .pro file with qtcreator and build or debug laigter. For windows, unfortunately, there are more steps to be done.
+
+First you will need to install qt. I strongly discourage the offline installer, use the web installer instead. In the components selection window you will need to select  qt creator under "qt >> developer and designers tools" and the mingw 7.3 32bit or 64bit toolchain under "qt >> developer and designers tools >> mingw 7.3.0" and "qt >> qt 5.13.0 >> mingw 7.3.0". Do not choose the msvc toolchain. If you choose both the 32 and 64 bit versions, make sure that only one version is in the system path, otherwise you will have problems compiling
+
+Then you will need to download and compile opencv 3.2. It must be version 3.2, it cannot be any other version. be warned. But to compile opencv you will need cmake, so download and install that too.
+
+Once you have installed cmake and downloaded opencv 3.2, folow this tutorial here:
+
+https://wiki.qt.io/How_to_setup_Qt_and_openCV_on_Windows
+
+But before clicking "generate" on cmake-gui, be sure to uncheck BUILD_opencv_python3 in case you have this flag and it is checked. I could not compile until I unchecked this. And also change EXECUTABLE_OUTPUT_PATH to C:\opencv-build\install\x86\mingw\bin wich is the path set on laigter.pro (or you could change the path on your laigter.pro to match your EXECUTABLE_OUTPUT_PATH)
+
+After several minutes, fortunately your compilation will be sucessfull. If that's the case, you can open the project on qt-creator, compile and run it. Once you want to deploy the application for windows, you will need the windeployqt command. Something like the following should be enough:
+
+```
+mkdir .\deploy
+windeployqt --dir .\deploy ..\build-laigter-Desktop_Qt_5_13_0_MinGW_32_bit-Release\release\laigter.exe
+copy /Y ..\build-laigter-Desktop_Qt_5_13_0_MinGW_32_bit-Release\release\laigter.exe .\deploy\laigter.exe
+```
+
+If for some reason the opencv libraries do not get copied, copy them also
+```
+copy /Y C:\opencv-build\install\x86\mingw\bin\libopencv_core320.dll .\deploy\
+copy /Y C:\opencv-build\install\x86\mingw\bin\libopencv_imgproc320.dll .\deploy\
+```

--- a/gui/presetsmanager.cpp
+++ b/gui/presetsmanager.cpp
@@ -305,3 +305,8 @@ void PresetsManager::on_pushButtonImportPreset_clicked()
     }
     update_presets();
 }
+
+Ui::preset_codes_array& PresetsManager::get_preset_codes()
+{
+    return presetCodes;
+}

--- a/gui/presetsmanager.h
+++ b/gui/presetsmanager.h
@@ -27,6 +27,9 @@
 #include "src/imageprocessor.h"
 
 namespace Ui {
+
+typedef QString preset_codes_array[30];
+
 class PresetsManager;
 }
 
@@ -37,6 +40,7 @@ class PresetsManager : public QDialog
 public:
     explicit PresetsManager(ProcessorSettings settings, QList <ImageProcessor *> *processorList, QWidget *parent = nullptr);
     ~PresetsManager();
+    static Ui::preset_codes_array& get_preset_codes();
 
 signals:
     void settingAplied();

--- a/main.cpp
+++ b/main.cpp
@@ -25,10 +25,101 @@
 #include <QStandardPaths>
 #include <QDebug>
 #include <QDir>
+#include <QCommandLineParser>
+#include "gui/presetsmanager.h"
+
+void applyPresetSettings(QByteArray& setting, ImageProcessor &p){
+    Ui::preset_codes_array& presetCodes = PresetsManager::get_preset_codes();
+    QList<QByteArray> aux = setting.split('\t');
+    if (aux[0] == presetCodes[0]){
+        p.set_normal_depth(aux[1].toInt());
+    }else if (aux[0] == presetCodes[1]){
+        p.set_normal_blur_radius(aux[1].toInt());
+    }else if (aux[0] == presetCodes[2]){
+        p.set_normal_bisel_depth(aux[1].toInt());
+    }else if (aux[0] == presetCodes[3]){
+        p.set_normal_bisel_distance(aux[1].toInt());
+    }else if (aux[0] == presetCodes[4]){
+        p.set_normal_bisel_blur_radius(aux[1].toInt());
+    }else if (aux[0] == presetCodes[5]){
+        p.set_normal_bisel_soft((bool)aux[1].toInt());
+    }else if (aux[0] == presetCodes[6]){
+        p.set_tileable((bool)aux[1].toInt());
+    }else if (aux[0] == presetCodes[7]){
+        p.set_normal_invert_x((bool)aux[1].toInt());
+    }else if (aux[0] == presetCodes[8]){
+        p.set_normal_invert_y((bool)aux[1].toInt());
+    }else if (aux[0] == presetCodes[9]){
+        p.set_parallax_type((ParallaxType)aux[1].toInt());
+    }else if (aux[0] == presetCodes[10]){
+        p.set_parallax_thresh(aux[1].toInt());
+    }else if (aux[0] == presetCodes[11]){
+        p.set_parallax_focus(aux[1].toInt());
+    }else if (aux[0] == presetCodes[12]){
+        p.set_parallax_soft(aux[1].toInt());
+    }else if (aux[0] == presetCodes[13]){
+        p.set_parallax_min(aux[1].toInt());
+    }else if (aux[0] == presetCodes[14]){
+        p.set_parallax_erode_dilate(aux[1].toInt());
+    }else if (aux[0] == presetCodes[15]){
+        p.set_parallax_brightness(aux[1].toInt());
+    }else if (aux[0] == presetCodes[16]){
+        p.set_parallax_contrast(aux[1].toInt());
+    }else if (aux[0] == presetCodes[17]){
+        p.set_parallax_invert((bool)aux[1].toInt());
+    }else if (aux[0] == presetCodes[18]){
+        p.set_specular_blur(aux[1].toInt());
+    }else if (aux[0] == presetCodes[19]){
+        p.set_specular_bright(aux[1].toInt());
+    }else if (aux[0] == presetCodes[20]){
+        p.set_specular_contrast(aux[1].toInt());
+    }else if (aux[0] == presetCodes[21]){
+        p.set_specular_thresh(aux[1].toInt());
+    }else if (aux[0] == presetCodes[22]){
+        p.set_specular_invert((bool)aux[1].toInt());
+    }else if (aux[0] == presetCodes[23]){
+        p.set_occlusion_blur(aux[1].toInt());
+    }else if (aux[0] == presetCodes[24]){
+        p.set_occlusion_bright(aux[1].toInt());
+    }else if (aux[0] == presetCodes[25]){
+        p.set_occlusion_invert((bool)aux[1].toInt());
+    }else if (aux[0] == presetCodes[26]){
+        p.set_occlusion_thresh(aux[1].toInt());
+    }else if (aux[0] == presetCodes[27]){
+        p.set_occlusion_contrast(aux[1].toInt());
+    }else if (aux[0] == presetCodes[28]){
+        p.set_occlusion_distance(aux[1].toInt());
+    }else if (aux[0] == presetCodes[29]){
+        p.set_occlusion_distance_mode((bool)aux[1].toInt());
+    }
+}
+
+void applyPresets(QString &preset, ImageProcessor &p){
+    QFile selected_preset(preset);
+    if(!selected_preset.open(QIODevice::ReadOnly)){
+        return;
+    }
+    QByteArray settings = selected_preset.readAll();
+    QList<QByteArray> settings_list = settings.split('\n');
+
+    for (int i=0; i< settings_list.count(); i++){
+        QByteArray setting = settings_list.at(i);
+        applyPresetSettings(setting, p);
+    }
+}
+
+QCoreApplication* createApplication(int &argc, char *argv[])
+{
+    for (int i = 1; i < argc; ++i)
+        if (!qstrcmp(argv[i], "--no-gui"))
+            return new QCoreApplication(argc, argv);
+    return new QApplication(argc, argv);
+}
 
 int main(int argc, char *argv[])
 {
     QCoreApplication::setApplicationName("laigter");
+    QCoreApplication::setApplicationVersion("1.5.1.0");
 
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 
@@ -53,17 +144,103 @@ int main(int argc, char *argv[])
         dir.mkpath(".");
 #endif
 
-    QApplication a(argc, argv);
-    a.installTranslator(&translator);
-    if (argc > 1){
-        if (*argv[1] == 's'){
-            a.setAttribute(Qt::AA_UseSoftwareOpenGL);
-            qDebug() << "Soft OpenGL";
+    QCommandLineParser argsParser;
+    argsParser.setApplicationDescription("Test helper");
+    argsParser.addHelpOption();
+    argsParser.addVersionOption();
+
+    QCommandLineOption softOpenGl(QStringList() << "s" << "software-opengl",
+        "Use software opengl renderer.");
+    argsParser.addOption(softOpenGl);
+
+    QCommandLineOption noGuiOption(QStringList() << "g" << "no-gui",
+        "do not start graphical interface");
+    argsParser.addOption(noGuiOption);
+
+    QCommandLineOption inputDiffuseTextureOption(QStringList() << "d" << "diffuse",
+        "diffuse texture to load",
+        "diffuse texture path");
+    argsParser.addOption(inputDiffuseTextureOption);
+
+    QCommandLineOption outputNormalTextureOption(QStringList() << "n" << "normal",
+        "generate normals");
+    argsParser.addOption(outputNormalTextureOption);
+
+    QCommandLineOption outputSpecularTextureOption(QStringList() << "c" << "specular",
+        "generate specular");
+    argsParser.addOption(outputSpecularTextureOption);
+
+    QCommandLineOption outputOcclusionTextureOption(QStringList() << "o" << "occlusion",
+        "generate occlusion");
+    argsParser.addOption(outputOcclusionTextureOption);
+
+    QCommandLineOption outputParallaxTextureOption(QStringList() << "p" << "parallax",
+        "generate parallax");
+    argsParser.addOption(outputParallaxTextureOption);
+
+    QCommandLineOption pressetOption(QStringList() << "r" << "preset",
+        "presset to load",
+        "preset file path");
+    argsParser.addOption(pressetOption);
+
+    QScopedPointer<QCoreApplication> app(createApplication(argc, argv));
+    argsParser.process(*app.data());
+
+    QString inputDiffuseTextureOptionValue = argsParser.value(inputDiffuseTextureOption);
+    if(!inputDiffuseTextureOptionValue.trimmed().isEmpty()){
+        QFileInfo info(inputDiffuseTextureOptionValue);
+        QString suffix = info.suffix(); // just the last suffix, not the complete one
+
+        QString pressetOptionValue = argsParser.value(pressetOption);
+        ImageLoader il;
+        bool succes;
+        QImage auximage = il.loadImage(inputDiffuseTextureOptionValue , &succes);
+        auximage = auximage.convertToFormat(QImage::Format_RGBA8888_Premultiplied);
+        ImageProcessor *processor = new ImageProcessor();
+        processor->loadImage(inputDiffuseTextureOptionValue , auximage);
+        if(!pressetOptionValue.trimmed().isEmpty()){
+            applyPresets(pressetOptionValue, *processor);
+        }
+        QString pathWithoutExtension = info.absoluteFilePath().remove("."+suffix);
+        if(argsParser.isSet(outputNormalTextureOption)){
+            QImage normal = processor->get_normal();
+            QString name = pathWithoutExtension+"_n."+suffix;
+            normal.save(name);
+        }
+        if(argsParser.isSet(outputSpecularTextureOption)){
+            QImage specular = processor->get_specular();
+            QString name = pathWithoutExtension+"_s."+suffix;
+            specular.save(name);
+        }
+        if(argsParser.isSet(outputOcclusionTextureOption)){
+            QImage occlusion = processor->get_occlusion();
+            QString name = pathWithoutExtension+"_o."+suffix;
+            occlusion.save(name);
+        }
+        if(argsParser.isSet(outputParallaxTextureOption)){
+            QImage parallax = processor->get_parallax();
+            QString name = pathWithoutExtension+"_p."+suffix;
+            parallax.save(name);
         }
     }
-    MainWindow w;
-    QGuiApplication::setWindowIcon(QIcon(":/images/laigter-icon.png"));
-    w.show();
-    qRegisterMetaType<ProcessedImage>("ProcessedImage");
-    return a.exec();
+
+    QApplication* a = qobject_cast<QApplication *>(app.data());
+    int returnCode;
+    if (a) {
+        a->installTranslator(&translator);
+        bool softOpenGlValue = argsParser.isSet(softOpenGl);
+        if (softOpenGlValue){
+            a->setAttribute(Qt::AA_UseSoftwareOpenGL);
+            qDebug() << "Soft OpenGL";
+        }
+        MainWindow w;
+        QGuiApplication::setWindowIcon(QIcon(":/images/laigter-icon.png"));
+        w.show();
+        qRegisterMetaType<ProcessedImage>("ProcessedImage");
+        returnCode = app->exec();
+    } else {
+        // do CLI only things here
+        returnCode = 0;
+    }
+    return returnCode;
 }


### PR DESCRIPTION
These changes implement an experimental cli export feature wich allows for selectively generating any number of the supported types of generated maps from a given diffuse texture (and optionally a given pressets file) and exiting without loading the main window.

Unrelated to the above mentioned feature, I made a bat script to simplify deploying on windows and added one line to gitignore to ignore the deploy directory