### PR TITLE
Install the MIME type file on UNIX-based systems

### DIFF
--- a/laigter.pro
+++ b/laigter.pro
@@ -115,11 +115,14 @@ unix{
     iconfiles.path = $$PREFIX/share/icons/hicolor/256x256/apps/
     appdatafiles.files = dist/laigter.appdata.xml
     appdatafiles.path = $$PREFIX/share/metainfo/
+	mimetypefiles.files = dist/x-laigter-project.xml
+    mimetypefiles.path = $$PREFIX/share/mime/packages/
 
     INSTALLS += target
     INSTALLS += shortcutfiles
     INSTALLS += iconfiles
     INSTALLS += appdatafiles
+    INSTALLS += mimetypefiles
 }
 
 DISTFILES += \
@@ -186,5 +189,3 @@ RESOURCES += \
 
 win32: RC_ICONS = icons\laigter_icon.ico
 mac: ICON = icons/laigter_icon.icns
-
-


### PR DESCRIPTION
This improves system integration by registering file associations automtaically when installing Laigter system-wide.