### PR TITLE
Fix various typos, improve normal map alpha channel tooltip

### DIFF
--- a/gui/exportwidget.cpp
+++ b/gui/exportwidget.cpp
@@ -173,7 +173,7 @@ void ExportWidget::on_pushButton_clicked()
     {
       saved &= ExportMap(TextureTypes::Occlussion, p, ui->lineEditOcclusionPostFix->text(), path, p->get_use_occlusion_alpha());
     }
-    if (ui->checkBoxDifusse->isChecked())
+    if (ui->checkBoxDiffuse->isChecked())
     {
       saved &= ExportMap(TextureTypes::Color, p, ui->lineEditDiffusePostFix->text(), path);
     }

--- a/gui/exportwidget.ui
+++ b/gui/exportwidget.ui
@@ -145,9 +145,9 @@
        </widget>
       </item>
       <item row="4" column="0">
-       <widget class="QCheckBox" name="checkBoxDifusse">
+       <widget class="QCheckBox" name="checkBoxDiffuse">
         <property name="text">
-         <string>Difusse</string>
+         <string>Diffuse</string>
         </property>
        </widget>
       </item>
@@ -244,7 +244,7 @@
         </item>
         <item>
          <property name="text">
-          <string>Sepparate Images</string>
+          <string>Separate Images</string>
          </property>
         </item>
        </widget>
@@ -279,7 +279,7 @@
       <item row="7" column="0" colspan="2">
        <widget class="QLabel" name="label">
         <property name="toolTip">
-         <string>Embedd this map as the alpha channel of normal map.</string>
+         <string>Embed the selected texture map in the alpha channel of the exported normal map image.</string>
         </property>
         <property name="text">
          <string>Normal Alpha Channel:</string>

--- a/gui/nb_selector.ui
+++ b/gui/nb_selector.ui
@@ -47,9 +47,9 @@
       </size>
      </property>
      <property name="styleSheet">
-      <string notr="true"> QPushButton { 
+      <string notr="true"> QPushButton {
                      border: 2px solid transparent;
-                     padding: 0px; 
+                     padding: 0px;
                      background: 2px solid rgba(29, 161, 242, 25);
                      }
                    QPushButton:pressed
@@ -103,9 +103,9 @@
       </size>
      </property>
      <property name="styleSheet">
-      <string notr="true"> QPushButton { 
+      <string notr="true"> QPushButton {
                      border: 2px solid transparent;
-                     padding: 0px; 
+                     padding: 0px;
                      background: 2px solid rgba(29, 161, 242, 25);
                      }
                    QPushButton:pressed
@@ -152,9 +152,9 @@
       </size>
      </property>
      <property name="styleSheet">
-      <string notr="true"> QPushButton { 
+      <string notr="true"> QPushButton {
                      border: 2px solid transparent;
-                     padding: 0px; 
+                     padding: 0px;
                      background: 2px solid rgba(29, 161, 242, 25);
                      }
                    QPushButton:pressed
@@ -226,7 +226,7 @@
      </widget>
      <widget class="QWidget" name="imagesTab">
       <attribute name="title">
-       <string>ExternalImages</string>
+       <string>External Images</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_3">
        <item row="0" column="0" colspan="2">
@@ -299,9 +299,9 @@
       </size>
      </property>
      <property name="styleSheet">
-      <string notr="true"> QPushButton { 
+      <string notr="true"> QPushButton {
                      border: 2px solid transparent;
-                     padding: 0px; 
+                     padding: 0px;
                      background: 2px solid rgba(29, 161, 242, 25);
                      }
                    QPushButton:pressed
@@ -348,9 +348,9 @@
       </size>
      </property>
      <property name="styleSheet">
-      <string notr="true"> QPushButton { 
+      <string notr="true"> QPushButton {
                      border: 2px solid transparent;
-                     padding: 0px; 
+                     padding: 0px;
                      background: 2px solid rgba(29, 161, 242, 25);
                      }
                    QPushButton:pressed
@@ -410,9 +410,9 @@
       </size>
      </property>
      <property name="styleSheet">
-      <string notr="true"> QPushButton { 
+      <string notr="true"> QPushButton {
                      border: 2px solid transparent;
-                     padding: 0px; 
+                     padding: 0px;
                      background: 2px solid rgba(29, 161, 242, 25);
                      }
                    QPushButton:pressed
@@ -459,9 +459,9 @@
       </size>
      </property>
      <property name="styleSheet">
-      <string notr="true"> QPushButton { 
+      <string notr="true"> QPushButton {
                      border: 2px solid transparent;
-                     padding: 0px; 
+                     padding: 0px;
                      background: 2px solid rgba(29, 161, 242, 25);
                      }
                    QPushButton:pressed
@@ -508,9 +508,9 @@
       </size>
      </property>
      <property name="styleSheet">
-      <string notr="true"> QPushButton { 
+      <string notr="true"> QPushButton {
                      border: 2px solid transparent;
-                     padding: 0px; 
+                     padding: 0px;
                      background: 2px solid rgba(29, 161, 242, 25);
                      }
                    QPushButton:pressed
@@ -557,9 +557,9 @@
       </size>
      </property>
      <property name="styleSheet">
-      <string notr="true"> QPushButton { 
+      <string notr="true"> QPushButton {
                      border: 2px solid transparent;
-                     padding: 0px; 
+                     padding: 0px;
                      background: 2px solid rgba(29, 161, 242, 25);
                      }
                    QPushButton:pressed

--- a/main_window.cpp
+++ b/main_window.cpp
@@ -728,7 +728,7 @@ void MainWindow::on_actionExport_triggered()
   //        info.absoluteFilePath().remove("." + suffix) + "_o." + suffix;
   //    n = *processor->get_occlusion();
   //    n.save(fileName);
-  //    message += tr("Occlussion map was exported.\n");
+  //    message += tr("Occlusion map was exported.\n");
   //  }
 
   //  if (ui->checkBoxExportPreview->isChecked())

--- a/main_window.ui
+++ b/main_window.ui
@@ -740,7 +740,7 @@
           </item>
           <item>
            <property name="text">
-            <string>Occlussion Map</string>
+            <string>Occlusion Map</string>
            </property>
           </item>
           <item>

--- a/translations/laigter_ca_ES.ts
+++ b/translations/laigter_ca_ES.ts
@@ -1610,7 +1610,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../gui/exportwidget.ui" line="150"/>
-        <source>Difusse</source>
+        <source>Diffuse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1665,7 +1665,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../gui/exportwidget.ui" line="247"/>
-        <source>Sepparate Images</source>
+        <source>Separate Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1695,7 +1695,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../gui/exportwidget.ui" line="282"/>
-        <source>Embedd this map as the alpha channel of normal map.</source>
+        <source>Embed the selected texture map in the alpha channel of the exported normal map image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1931,7 +1931,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../main_window.ui" line="743"/>
-        <source>Occlussion Map</source>
+        <source>Occlusion Map</source>
         <translation>Mapa d&apos;Oclusió</translation>
     </message>
     <message>
@@ -2311,7 +2311,7 @@ p, li { white-space: pre-wrap; }
 </translation>
     </message>
     <message>
-        <source>Occlussion map was exported.
+        <source>Occlusion map was exported.
 </source>
         <translation type="vanished">S&apos;ha exportat el mapa d&apos;oclusió.
 </translation>
@@ -2419,7 +2419,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../gui/nb_selector.ui" line="229"/>
-        <source>ExternalImages</source>
+        <source>External Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/laigter_da.ts
+++ b/translations/laigter_da.ts
@@ -1606,7 +1606,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../gui/exportwidget.ui" line="150"/>
-        <source>Difusse</source>
+        <source>Diffuse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1661,7 +1661,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../gui/exportwidget.ui" line="247"/>
-        <source>Sepparate Images</source>
+        <source>Separate Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1691,7 +1691,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../gui/exportwidget.ui" line="282"/>
-        <source>Embedd this map as the alpha channel of normal map.</source>
+        <source>Embed the selected texture map in the alpha channel of the exported normal map image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1927,7 +1927,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../main_window.ui" line="743"/>
-        <source>Occlussion Map</source>
+        <source>Occlusion Map</source>
         <translation>Okklusionskort</translation>
     </message>
     <message>
@@ -2307,7 +2307,7 @@ p, li { white-space: pre-wrap; }
 </translation>
     </message>
     <message>
-        <source>Occlussion map was exported.
+        <source>Occlusion map was exported.
 </source>
         <translation type="vanished">Okklusionskort blev eksporteret.
 </translation>
@@ -2415,7 +2415,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../gui/nb_selector.ui" line="229"/>
-        <source>ExternalImages</source>
+        <source>External Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/laigter_de.ts
+++ b/translations/laigter_de.ts
@@ -2938,7 +2938,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../gui/exportwidget.ui" line="150"/>
-        <source>Difusse</source>
+        <source>Diffuse</source>
         <translation>Diffus</translation>
     </message>
     <message>
@@ -2988,7 +2988,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../gui/exportwidget.ui" line="255"/>
-        <source>Embedd this map as the alpha channel of normal map.</source>
+        <source>Embed the selected texture map in the alpha channel of the exported normal map image.</source>
         <translatorcomment>??? What is this saying?</translatorcomment>
         <translation>Dieses Feld als Alphakanal des Normalfelds einbinden.</translation>
     </message>
@@ -3228,7 +3228,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../main_window.ui" line="743"/>
-        <source>Occlussion Map</source>
+        <source>Occlusion Map</source>
         <translation>Umgebungverdeckungsfeld</translation>
     </message>
     <message>
@@ -3609,7 +3609,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../gui/nb_selector.ui" line="209"/>
-        <source>ExternalImages</source>
+        <source>External Images</source>
         <translation>Externe BIlder</translation>
     </message>
     <message>

--- a/translations/laigter_el.ts
+++ b/translations/laigter_el.ts
@@ -1618,7 +1618,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../gui/exportwidget.ui" line="150"/>
-        <source>Difusse</source>
+        <source>Diffuse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1673,7 +1673,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../gui/exportwidget.ui" line="247"/>
-        <source>Sepparate Images</source>
+        <source>Separate Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1703,7 +1703,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../gui/exportwidget.ui" line="282"/>
-        <source>Embedd this map as the alpha channel of normal map.</source>
+        <source>Embed the selected texture map in the alpha channel of the exported normal map image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1939,7 +1939,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../main_window.ui" line="743"/>
-        <source>Occlussion Map</source>
+        <source>Occlusion Map</source>
         <translation>Χάρτης Απόφραξης</translation>
     </message>
     <message>
@@ -2355,7 +2355,7 @@ p, li { white-space: pre-wrap; }
 </translation>
     </message>
     <message>
-        <source>Occlussion map was exported.
+        <source>Occlusion map was exported.
 </source>
         <translation type="vanished">Έγινε εξαγωγή του χάρτη εμποδίων.
 </translation>
@@ -2462,7 +2462,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../gui/nb_selector.ui" line="229"/>
-        <source>ExternalImages</source>
+        <source>External Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/laigter_en.ts
+++ b/translations/laigter_en.ts
@@ -1594,7 +1594,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../gui/exportwidget.ui" line="150"/>
-        <source>Difusse</source>
+        <source>Diffuse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1649,7 +1649,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../gui/exportwidget.ui" line="247"/>
-        <source>Sepparate Images</source>
+        <source>Separate Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1679,7 +1679,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../gui/exportwidget.ui" line="282"/>
-        <source>Embedd this map as the alpha channel of normal map.</source>
+        <source>Embed the selected texture map in the alpha channel of the exported normal map image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1915,7 +1915,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../main_window.ui" line="743"/>
-        <source>Occlussion Map</source>
+        <source>Occlusion Map</source>
         <translation></translation>
     </message>
     <message>
@@ -2295,7 +2295,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../gui/nb_selector.ui" line="229"/>
-        <source>ExternalImages</source>
+        <source>External Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/laigter_es.ts
+++ b/translations/laigter_es.ts
@@ -1602,7 +1602,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../gui/exportwidget.ui" line="150"/>
-        <source>Difusse</source>
+        <source>Diffuse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1657,7 +1657,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../gui/exportwidget.ui" line="247"/>
-        <source>Sepparate Images</source>
+        <source>Separate Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1687,7 +1687,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../gui/exportwidget.ui" line="282"/>
-        <source>Embedd this map as the alpha channel of normal map.</source>
+        <source>Embed the selected texture map in the alpha channel of the exported normal map image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1925,7 +1925,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../main_window.ui" line="743"/>
-        <source>Occlussion Map</source>
+        <source>Occlusion Map</source>
         <translation>Mapa de Oclusión</translation>
     </message>
     <message>
@@ -2345,7 +2345,7 @@ p, li { white-space: pre-wrap; }
 </translation>
     </message>
     <message>
-        <source>Occlussion map was exported.
+        <source>Occlusion map was exported.
 </source>
         <translation type="vanished">Se exportó el mapa de oclusión.
 </translation>
@@ -2453,7 +2453,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../gui/nb_selector.ui" line="229"/>
-        <source>ExternalImages</source>
+        <source>External Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/laigter_fr.ts
+++ b/translations/laigter_fr.ts
@@ -1610,7 +1610,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../gui/exportwidget.ui" line="150"/>
-        <source>Difusse</source>
+        <source>Diffuse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1665,7 +1665,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../gui/exportwidget.ui" line="247"/>
-        <source>Sepparate Images</source>
+        <source>Separate Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1695,7 +1695,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../gui/exportwidget.ui" line="282"/>
-        <source>Embedd this map as the alpha channel of normal map.</source>
+        <source>Embed the selected texture map in the alpha channel of the exported normal map image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1930,7 +1930,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../main_window.ui" line="743"/>
-        <source>Occlussion Map</source>
+        <source>Occlusion Map</source>
         <translation>Carte d&apos;occlusion</translation>
     </message>
     <message>
@@ -2338,7 +2338,7 @@ p, li { white-space: pre-wrap; }
 </translation>
     </message>
     <message>
-        <source>Occlussion map was exported.
+        <source>Occlusion map was exported.
 </source>
         <translation type="vanished">Se exportó el mapa de oclusión.
 </translation>
@@ -2445,7 +2445,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../gui/nb_selector.ui" line="229"/>
-        <source>ExternalImages</source>
+        <source>External Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/laigter_jp.ts
+++ b/translations/laigter_jp.ts
@@ -1622,7 +1622,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../gui/exportwidget.ui" line="150"/>
-        <source>Difusse</source>
+        <source>Diffuse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1677,7 +1677,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../gui/exportwidget.ui" line="247"/>
-        <source>Sepparate Images</source>
+        <source>Separate Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1707,7 +1707,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../gui/exportwidget.ui" line="282"/>
-        <source>Embedd this map as the alpha channel of normal map.</source>
+        <source>Embed the selected texture map in the alpha channel of the exported normal map image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1947,7 +1947,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../main_window.ui" line="743"/>
-        <source>Occlussion Map</source>
+        <source>Occlusion Map</source>
         <translation>オクルージョンマップ</translation>
     </message>
     <message>
@@ -2353,7 +2353,7 @@ p, li { white-space: pre-wrap; }
         <translation type="vanished">スペキュラーマップのエクスポート完了!</translation>
     </message>
     <message>
-        <source>Occlussion map was exported.
+        <source>Occlusion map was exported.
 </source>
         <translation type="vanished">オクルージョンマップのエクスポート完了!</translation>
     </message>
@@ -2430,7 +2430,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../gui/nb_selector.ui" line="229"/>
-        <source>ExternalImages</source>
+        <source>External Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/laigter_pt_BR.ts
+++ b/translations/laigter_pt_BR.ts
@@ -1610,7 +1610,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../gui/exportwidget.ui" line="150"/>
-        <source>Difusse</source>
+        <source>Diffuse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1665,7 +1665,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../gui/exportwidget.ui" line="247"/>
-        <source>Sepparate Images</source>
+        <source>Separate Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1695,7 +1695,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../gui/exportwidget.ui" line="282"/>
-        <source>Embedd this map as the alpha channel of normal map.</source>
+        <source>Embed the selected texture map in the alpha channel of the exported normal map image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1931,7 +1931,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../main_window.ui" line="743"/>
-        <source>Occlussion Map</source>
+        <source>Occlusion Map</source>
         <translation>Mapa de Oclusão</translation>
     </message>
     <message>
@@ -2311,7 +2311,7 @@ p, li { white-space: pre-wrap; }
 </translation>
     </message>
     <message>
-        <source>Occlussion map was exported.
+        <source>Occlusion map was exported.
 </source>
         <translation type="vanished">Mapa de oclusão foi exportado.
 </translation>
@@ -2419,7 +2419,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../gui/nb_selector.ui" line="229"/>
-        <source>ExternalImages</source>
+        <source>External Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/laigter_tr.ts
+++ b/translations/laigter_tr.ts
@@ -1598,7 +1598,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../gui/exportwidget.ui" line="150"/>
-        <source>Difusse</source>
+        <source>Diffuse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1653,7 +1653,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../gui/exportwidget.ui" line="247"/>
-        <source>Sepparate Images</source>
+        <source>Separate Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1683,7 +1683,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../gui/exportwidget.ui" line="282"/>
-        <source>Embedd this map as the alpha channel of normal map.</source>
+        <source>Embed the selected texture map in the alpha channel of the exported normal map image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1919,7 +1919,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../main_window.ui" line="743"/>
-        <source>Occlussion Map</source>
+        <source>Occlusion Map</source>
         <translation></translation>
     </message>
     <message>
@@ -2312,9 +2312,9 @@ p, li { white-space: pre-wrap; }
         <translation type="vanished">Specular map dışa aktarıldı.</translation>
     </message>
     <message>
-        <source>Occlussion map was exported.
+        <source>Occlusion map was exported.
 </source>
-        <translation type="vanished">Occlussion map dışa aktarıldı.</translation>
+        <translation type="vanished">Occlusion map dışa aktarıldı.</translation>
     </message>
     <message>
         <source>Preview was exported.
@@ -2389,7 +2389,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../gui/nb_selector.ui" line="229"/>
-        <source>ExternalImages</source>
+        <source>External Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>


### PR DESCRIPTION
Thanks to TheTrueDuck for pointing to those typos :slightly_smiling_face: 

This closes https://github.com/azagaya/laigter/issues/86.

Note that this doesn't address the Sprite frames H/V part in https://github.com/azagaya/laigter/issues/86#issuecomment-873462059, as I feel the current syntax is OK (H = Horizontal, V = Vertical).

The name "occlussion" was left as-is in the project files to avoid breaking compatibility.