### PR TITLE
Fix specular maps outputting black images when tile mode enabled

### DIFF
--- a/src/image_processor.cpp
+++ b/src/image_processor.cpp
@@ -726,7 +726,10 @@ CImg<float> ImageProcessor::modify_parallax()
 
 CImg<float> ImageProcessor::modify_specular()
 {
-  sprite.get_image(TextureTypes::SpecularBase, &specular);
+  if (tileable)
+    sprite.get_image(TextureTypes::Neighbours, &specular);
+  else
+    sprite.get_image(TextureTypes::SpecularBase, &specular);
   specular = specular.convertToFormat(QImage::Format_Grayscale8);
   CImg<uchar> img = QImage2CImg(specular);
   CImg<float> img_float(img);

--- a/src/image_processor.cpp
+++ b/src/image_processor.cpp
@@ -826,6 +826,7 @@ void ImageProcessor::generate_normal_map(bool updateEnhance, bool updateBump, bo
     set_current_heightmap(0);
     calculate_heightmap();
     calculate_distance();
+    calculate_specular();
   }
 
   if (update_tileable)


### PR DESCRIPTION
Fixes #96

Specular modification wasn't taking into account the neighbours, generating a regular sized image, and so `ImageProcessor::calculate_specular()` was trying to crop the new specular image to the size it already was. Apparently, the CImg default behaviour without adding a `boundary_conditions` flag to `crop()` in this situation is to fill the image in with black (???)

I changed `ImageProcessor::modify_specular()` to use the same process as the parallax generation, i.e. use `TextureTypes::Neighbours` image if `tileable`, else `TextureTypes::SpecularBase`. This generates the bigger image for tile mode that can be successfully cropped, which fixes the black output image, and also correctly fixes up the edges of the specular map for tiling.

Since the heightmap is regenerated when `update_tileable`  is set to true by tile mode properties being changed, I added `calculate_specular()` alongside it so specular is also updated.